### PR TITLE
Added Qin et al. 2020 (indirect) ionized fraction from CMB

### DIFF
--- a/corecon/data/ionized_fraction/Qin_et_al_2020.py
+++ b/corecon/data/ionized_fraction/Qin_et_al_2020.py
@@ -1,0 +1,34 @@
+dictionary_tag         = "Qin et al. 2020 (subm.)"
+
+reference              = "Qin, Poulin, Mesinger, Greig, Murray, Park, Jaehong; subm. (2020)"
+
+url                    = "https://arxiv.org/pdf/2006.16828.pdf"
+
+description            = \
+"""
+Ionized fraction for physical models (simulated with 21cmFAST) that satisfy the CMB optical depth constraint (Planck 2018) and also an x_HI(5.9)<0.06+0.05(1σ) constraint from QSO dark fraction. Note that this constraint is model dependent, for a simplistic tanh model it would be stronger.
+"""
+
+data_structure         = "" #grid or points
+
+extracted              = False #False if the original paper provides number, True if extracted from plots
+
+ndim                   = 1
+
+dimensions_descriptors = [ redshift ]
+
+axes                   = [ [10.] ]
+
+values                 = [ 0.849 ]
+
+err_up                 = [ nan ]
+
+err_down               = [ nan ]
+
+err_up2                = [ nan ]
+
+err_down2              = [ nan ]
+
+upper_lim              = [ False ]
+
+lower_lim              = [ True ]

--- a/corecon/data/ionized_fraction/Qin_et_al_2020.py
+++ b/corecon/data/ionized_fraction/Qin_et_al_2020.py
@@ -9,25 +9,25 @@ description            = \
 Ionized fraction for physical models (simulated with 21cmFAST) that satisfy the CMB optical depth constraint (Planck 2018) and also an x_HI(5.9)<0.06+0.05(1σ) constraint from QSO dark fraction. Note that this constraint is model dependent, for a simplistic tanh model it would be stronger.
 """
 
-data_structure         = "" #grid or points
+data_structure         = "points" #grid or points
 
 extracted              = False #False if the original paper provides number, True if extracted from plots
 
 ndim                   = 1
 
-dimensions_descriptors = [ redshift ]
+dimensions_descriptors = [ "redshift" ]
 
-axes                   = [ [10.] ]
+axes                   = [ 10 ]
 
-values                 = [ 0.849 ]
+values                 = [ 1-0.849 ]
 
-err_up                 = [ nan ]
+err_up                 = [ None ]
 
-err_down               = [ nan ]
+err_down               = [ None ]
 
-err_up2                = [ nan ]
+err_up2                = [ None ]
 
-err_down2              = [ nan ]
+err_down2              = [ None ]
 
 upper_lim              = [ False ]
 

--- a/corecon/data/ionized_fraction/Qin_et_al_2020.py
+++ b/corecon/data/ionized_fraction/Qin_et_al_2020.py
@@ -29,6 +29,6 @@ err_up2                = [ None ]
 
 err_down2              = [ None ]
 
-upper_lim              = [ False ]
+upper_lim              = [ True ]
 
-lower_lim              = [ True ]
+lower_lim              = [ False ]


### PR DESCRIPTION
Hi,

I have added the data for this ionized fraction constraint. It is given as an "1 sigma" upper limit [here](https://arxiv.org/abs/2006.16828) [actually lower limit on xHI] so I'm not sure if I wrote the entry correctly: Do I just put a `value` and no errors with `upper_lim` to `True`?

Also I'm not sure how to add the constraint to the documentation.
**Edit**: My PR seems to break the [tutorial](https://corecon.readthedocs.io/en/latest/tutorial.html#tutorial) but it's just because it's constraint number 31 and the tutorial can only plot up to 30 constraints (`marker` has 3 items).
```
Traceback (most recent call last):
  File "tutorial.py", line 22, in <module>
    fmt = "%sC%i"%(markers[ik//10], ik%10)
IndexError: list index out of range
```

**Edit:** Actually it might be better not to include this model-dependent "xHI" constraint because the CMB constraint is by itself an integral constraint (which is already included) and this one might be misleading.

Cheers,
Stefan