### PR TITLE
Assert that field in get() is valid instead of silently returning None

### DIFF
--- a/corecon/__init__.py
+++ b/corecon/__init__.py
@@ -440,10 +440,8 @@ def get(field):
     :return: A dictionary of constraints.
     :rtype: dict (None if field is not available).
     """
-    if field in __fields__:
-        return copy.deepcopy(__dicts__[field])
-    else:
-        return None
+    assert field in __fields__, 'ERROR: {0:} is not a valid field.'.format(field)
+    return copy.deepcopy(__dicts__[field])
 
 def print_all_entries():
     """Prints all entries available in corecon.


### PR DESCRIPTION
Hi again,

I noticed that the code just accepts typos like `crc.get('To')` and other invalid fields. Since this would lead to an error in the users code sooner or later, I'd rather raise an exception immediately instead of returning `None` (which is presumably harder to debug).

Cheers,
Stefan